### PR TITLE
Rename JSContext to Context, keep backwards-compatible alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ Uses uv. Run tests like this:
 Run the development version of the tool like this:
 
     uv run python -c '
-    from microjs import JSContext
-    ctx = JSContext(memory_limit=1024*1024, time_limit=5.0)
+    from microjs import Context
+    ctx = Context(memory_limit=1024*1024, time_limit=5.0)
     print(ctx.eval("1 + 2"))
     '
 Always practice TDD: write a faliing test, watch it fail, then make it pass.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ pip install micro-javascript
 ## Usage
 
 ```python
-from microjs import JSContext
+from microjs import Context
 
 # Create a context with optional limits
-ctx = JSContext(memory_limit=1024*1024, time_limit=5.0)
+ctx = Context(memory_limit=1024*1024, time_limit=5.0)
 
 # Evaluate JavaScript code
 result = ctx.eval("1 + 2")  # Returns 3
@@ -67,7 +67,7 @@ try {
 Use `set()` and `get()` to pass values between Python and JavaScript:
 
 ```python
-ctx = JSContext()
+ctx = Context()
 
 # Set a Python value as a JavaScript global variable
 ctx.set("x", 42)
@@ -89,7 +89,7 @@ total = ctx.get("total")  # Returns 6
 You can expose Python functions to JavaScript by setting them as global variables:
 
 ```python
-ctx = JSContext()
+ctx = Context()
 
 # Define a Python function
 def add(a, b):
@@ -109,7 +109,7 @@ Arrays and objects are passed as internal JavaScript types (`JSArray`, `JSObject
 ```python
 from microjs.values import JSObject, JSArray
 
-ctx = JSContext()
+ctx = Context()
 
 # Access array elements via ._elements
 def sum_array(arr):

--- a/spec.md
+++ b/spec.md
@@ -178,7 +178,7 @@ Based on mquickjs_opcode.h, the VM uses these opcodes:
 
 ### Phase 4: Virtual Machine
 - [x] Implement VM core (vm.py)
-- [x] Implement JSContext public API (context.py)
+- [x] Implement Context public API (context.py)
 - [ ] Implement memory limits (basic structure exists)
 - [ ] Implement time limits (basic structure exists)
 - [ ] Implement garbage collector
@@ -216,10 +216,10 @@ Based on mquickjs_opcode.h, the VM uses these opcodes:
 The main public API should be simple and Pythonic:
 
 ```python
-from microjs import JSContext
+from microjs import Context
 
 # Create a context with optional limits
-ctx = JSContext(memory_limit=1024*1024, time_limit=5.0)
+ctx = Context(memory_limit=1024*1024, time_limit=5.0)
 
 # Evaluate JavaScript code
 result = ctx.eval("1 + 2")  # Returns Python int 3
@@ -261,7 +261,7 @@ microjs/
   src/
     microjs/
       __init__.py       # Public API exports
-      context.py        # JSContext main class
+      context.py        # Context main class
       values.py         # JavaScript value types
       tokens.py         # Token definitions
       lexer.py          # Tokenizer

--- a/src/microjs/__init__.py
+++ b/src/microjs/__init__.py
@@ -9,12 +9,12 @@ Based on: https://github.com/bellard/mquickjs
 
 __version__ = "0.1.0"
 
-from .context import JSContext
+from .context import Context, JSContext
 from .errors import JSError, JSSyntaxError, MemoryLimitError, TimeLimitError
 from .values import UNDEFINED, NULL
 
 __all__ = [
-    "JSContext",
+    "Context",
     "JSError",
     "JSSyntaxError",
     "MemoryLimitError",

--- a/src/microjs/context.py
+++ b/src/microjs/context.py
@@ -25,7 +25,7 @@ from .values import (
 from .errors import JSError, MemoryLimitError, TimeLimitError
 
 
-class JSContext:
+class Context:
     """JavaScript execution context with configurable limits."""
 
     def __init__(
@@ -1296,3 +1296,8 @@ class JSContext:
         if callable(value):
             return value
         return UNDEFINED
+
+
+# Backwards-compatible alias: JSContext was the original name and may be used
+# by existing code. Keep this alias to avoid breaking changes.
+JSContext = Context

--- a/src/microjs/values.py
+++ b/src/microjs/values.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 import math
 
 if TYPE_CHECKING:
-    from .context import JSContext
+    from .context import Context
 
 
 class JSUndefined:

--- a/tests/test_arrow_functions.py
+++ b/tests/test_arrow_functions.py
@@ -1,7 +1,7 @@
 """Test arrow function syntax."""
 
 import pytest
-from microjs import JSContext
+from microjs import Context
 
 
 class TestArrowFunctionBasics:
@@ -9,31 +9,31 @@ class TestArrowFunctionBasics:
 
     def test_simple_arrow(self):
         """Simple arrow function with expression body."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var f = x => x * 2; f(5)")
         assert result == 10
 
     def test_arrow_no_params(self):
         """Arrow function with no parameters."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var f = () => 42; f()")
         assert result == 42
 
     def test_arrow_multiple_params(self):
         """Arrow function with multiple parameters."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var f = (a, b) => a + b; f(3, 4)")
         assert result == 7
 
     def test_arrow_with_block(self):
         """Arrow function with block body."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var f = (x) => { return x * 3; }; f(4)")
         assert result == 12
 
     def test_arrow_single_param_no_parens(self):
         """Single parameter doesn't need parentheses."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var f = n => n + 1; f(10)")
         assert result == 11
 
@@ -43,19 +43,19 @@ class TestArrowFunctionExpressions:
 
     def test_arrow_iife(self):
         """Immediately invoked arrow function."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("((x) => x + 1)(5)")
         assert result == 6
 
     def test_arrow_in_array(self):
         """Arrow functions in array literals."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("[1, 2, 3].map(x => x * 2)")
         assert list(result) == [2, 4, 6]
 
     def test_arrow_in_callback(self):
         """Arrow function as callback."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("[1, 2, 3, 4].filter(x => x > 2)")
         assert list(result) == [3, 4]
 
@@ -65,7 +65,7 @@ class TestArrowFunctionScope:
 
     def test_arrow_captures_outer_var(self):
         """Arrow function captures outer variables."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var x = 10;
@@ -77,7 +77,7 @@ class TestArrowFunctionScope:
 
     def test_arrow_closure(self):
         """Arrow function creates proper closures."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             function makeAdder(n) {
@@ -95,13 +95,13 @@ class TestArrowFunctionEdgeCases:
 
     def test_arrow_returns_object(self):
         """Arrow function returning object literal (needs parens)."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var f = () => ({ x: 1, y: 2 }); f().x")
         assert result == 1
 
     def test_arrow_multiple_statements(self):
         """Arrow function with multiple statements in block."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var f = (a, b) => {
@@ -115,6 +115,6 @@ class TestArrowFunctionEdgeCases:
 
     def test_nested_arrow_functions(self):
         """Nested arrow functions."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var f = x => y => x + y; f(3)(4)")
         assert result == 7

--- a/tests/test_builtin_funcs.py
+++ b/tests/test_builtin_funcs.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from microjs import JSContext
+from microjs import Context
 
 
 def get_test_functions_from_js(js_file_path: Path) -> list[tuple[str, str]]:
@@ -94,7 +94,7 @@ def test_builtin_function(func_name: str):
     if func_name in FAILING_TESTS:
         pytest.xfail(FAILING_TESTS[func_name])
 
-    ctx = JSContext(time_limit=5.0)
+    ctx = Context(time_limit=5.0)
 
     # Load all the function definitions
     ctx.eval(_FUNC_CODE)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -6,12 +6,12 @@ These tests verify that microjs correctly implements JavaScript behavior.
 
 import pytest
 
-from microjs import JSContext
+from microjs import Context
 
 
 def run_js(js_code):
     """Run JavaScript code and return the result."""
-    ctx = JSContext()
+    ctx = Context()
     return ctx.eval(js_code)
 
 

--- a/tests/test_function_methods.py
+++ b/tests/test_function_methods.py
@@ -1,7 +1,7 @@
 """Test Function.prototype methods: bind, call, apply."""
 
 import pytest
-from microjs import JSContext
+from microjs import Context
 
 
 class TestFunctionBind:
@@ -9,7 +9,7 @@ class TestFunctionBind:
 
     def test_bind_this(self):
         """Bind this context."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var obj = { x: 10 };
@@ -22,7 +22,7 @@ class TestFunctionBind:
 
     def test_bind_partial_args(self):
         """Bind with partial arguments."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             function add(a, b) { return a + b; }
@@ -34,7 +34,7 @@ class TestFunctionBind:
 
     def test_bind_multiple_args(self):
         """Bind with multiple arguments."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             function greet(greeting, name) {
@@ -48,7 +48,7 @@ class TestFunctionBind:
 
     def test_bind_preserves_length(self):
         """Bound function has correct length property."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             function add(a, b, c) { return a + b + c; }
@@ -64,7 +64,7 @@ class TestFunctionCall:
 
     def test_call_with_this(self):
         """Call with specific this value."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var obj = { x: 5 };
@@ -76,7 +76,7 @@ class TestFunctionCall:
 
     def test_call_with_args(self):
         """Call with arguments."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             function add(a, b) { return a + b; }
@@ -87,7 +87,7 @@ class TestFunctionCall:
 
     def test_call_on_method(self):
         """Call method with different this."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var obj1 = { name: "obj1" };
@@ -104,7 +104,7 @@ class TestFunctionApply:
 
     def test_apply_with_this(self):
         """Apply with specific this value."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var obj = { x: 10 };
@@ -116,7 +116,7 @@ class TestFunctionApply:
 
     def test_apply_with_array_args(self):
         """Apply with array of arguments."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             function add(a, b, c) { return a + b + c; }
@@ -127,7 +127,7 @@ class TestFunctionApply:
 
     def test_apply_for_max(self):
         """Use apply to spread array to custom function."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             function findMax(a, b, c, d, e) {
@@ -146,7 +146,7 @@ class TestFunctionApply:
 
     def test_apply_empty_args(self):
         """Apply with no arguments array."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             function count() { return arguments.length; }

--- a/tests/test_js_basic.py
+++ b/tests/test_js_basic.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from microjs import JSContext
+from microjs import Context
 
 
 def get_basic_test_files():
@@ -47,7 +47,7 @@ def get_mquickjs_test_files():
 def test_basic_js(name: str, path: Path):
     """Run a basic JavaScript test file."""
     source = path.read_text(encoding="utf-8")
-    ctx = JSContext()
+    ctx = Context()
     # Execute the script - if it throws, the test fails
     ctx.eval(source)
 
@@ -69,7 +69,7 @@ def test_compat_js(name: str, path: Path):
     source = path.read_text(encoding="utf-8")
     # mandelbrot.js needs more time to render
     time_limit = 30.0 if "mandelbrot" in name else 2.0
-    ctx = JSContext(time_limit=time_limit)
+    ctx = Context(time_limit=time_limit)
     # Execute the script - if it throws, the test fails
     ctx.eval(source)
 
@@ -87,6 +87,6 @@ def test_mquickjs_js(name: str, path: Path):
     Watch for xfail tests that start passing!
     """
     source = path.read_text(encoding="utf-8")
-    ctx = JSContext(time_limit=2.0)  # Timeout to avoid infinite loops
+    ctx = Context(time_limit=2.0)  # Timeout to avoid infinite loops
     # Execute the script - if it throws, the test fails
     ctx.eval(source)

--- a/tests/test_jscontext_regexp.py
+++ b/tests/test_jscontext_regexp.py
@@ -1,7 +1,7 @@
-"""Test RegExp integration with JSContext."""
+"""Test RegExp integration with Context."""
 
 import pytest
-from microjs import JSContext
+from microjs import Context
 
 
 class TestRegExpConstructor:
@@ -9,25 +9,25 @@ class TestRegExpConstructor:
 
     def test_new_regexp_basic(self):
         """Create RegExp with constructor."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('var re = new RegExp("abc"); re.source')
         assert result == "abc"
 
     def test_new_regexp_flags(self):
         """Create RegExp with flags."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('var re = new RegExp("abc", "gi"); re.flags')
         assert result == "gi"
 
     def test_regexp_global_flag(self):
         """Check global flag property."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('var re = new RegExp("abc", "g"); re.global')
         assert result is True
 
     def test_regexp_ignorecase_flag(self):
         """Check ignoreCase flag property."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('var re = new RegExp("abc", "i"); re.ignoreCase')
         assert result is True
 
@@ -37,25 +37,25 @@ class TestRegExpTest:
 
     def test_simple_match(self):
         """Test simple pattern match."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('var re = new RegExp("hello"); re.test("hello world")')
         assert result is True
 
     def test_no_match(self):
         """Test no match."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('var re = new RegExp("hello"); re.test("goodbye")')
         assert result is False
 
     def test_case_insensitive_match(self):
         """Test case insensitive match."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('var re = new RegExp("hello", "i"); re.test("HELLO")')
         assert result is True
 
     def test_digit_pattern(self):
         """Test digit pattern."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('var re = new RegExp("\\\\d+"); re.test("abc123")')
         assert result is True
 
@@ -65,7 +65,7 @@ class TestRegExpExec:
 
     def test_exec_match(self):
         """Test exec returns match array."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var re = new RegExp("(\\\\w+)@(\\\\w+)");
@@ -77,7 +77,7 @@ class TestRegExpExec:
 
     def test_exec_group(self):
         """Test exec captures groups."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var re = new RegExp("(\\\\w+)@(\\\\w+)");
@@ -89,13 +89,13 @@ class TestRegExpExec:
 
     def test_exec_no_match(self):
         """Test exec returns null on no match."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('var re = new RegExp("xyz"); re.exec("abc")')
         assert result is None
 
     def test_exec_index(self):
         """Test exec result has index."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var re = new RegExp("world");
@@ -111,7 +111,7 @@ class TestRegExpGlobal:
 
     def test_global_exec_advances(self):
         """Test exec with global flag advances lastIndex."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var re = new RegExp("a", "g");
@@ -127,7 +127,7 @@ class TestRegExpGlobal:
 
     def test_lastindex_property(self):
         """Test lastIndex property is updated."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var re = new RegExp("a", "g");
@@ -145,13 +145,13 @@ class TestRegExpPatterns:
 
     def test_word_boundary(self):
         """Test word boundary."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('new RegExp("\\\\bword\\\\b").test("a word here")')
         assert result is True
 
     def test_anchors(self):
         """Test anchors."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('new RegExp("^hello").test("hello world")')
         assert result is True
         result = ctx.eval('new RegExp("^hello").test("say hello")')
@@ -159,7 +159,7 @@ class TestRegExpPatterns:
 
     def test_quantifiers(self):
         """Test quantifiers."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('new RegExp("a+").test("aaa")')
         assert result is True
         result = ctx.eval('new RegExp("a{2,3}").test("aaaa")')
@@ -167,7 +167,7 @@ class TestRegExpPatterns:
 
     def test_character_class(self):
         """Test character classes."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('new RegExp("[a-z]+").test("hello")')
         assert result is True
         result = ctx.eval('new RegExp("[0-9]+").test("123")')

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -31,7 +31,7 @@ def find_return_comments(code_block: str) -> list[tuple[int, str, str]]:
 def get_base_namespace() -> dict:
     """Get a namespace with common imports for README examples."""
     namespace = {}
-    exec("from microjs import JSContext", namespace)
+    exec("from microjs import Context", namespace)
     exec("from microjs.values import JSObject, JSArray", namespace)
     return namespace
 
@@ -63,8 +63,8 @@ class TestReadmeExamples:
         """Test that we can extract Python blocks from README."""
         blocks = extract_python_blocks(readme_content)
         assert len(blocks) > 0, "Should find at least one Python block"
-        # First block should contain JSContext
-        assert "JSContext" in blocks[0]
+        # First block should contain Context
+        assert "Context" in blocks[0]
 
     def test_find_return_comments(self):
         """Test that we can find return comments in code."""

--- a/tests/test_rect.py
+++ b/tests/test_rect.py
@@ -8,7 +8,7 @@ classes to the JavaScript context, demonstrating Python/JS interop.
 import pytest
 from pathlib import Path
 
-from microjs import JSContext
+from microjs import Context
 from microjs.values import JSObject, JSCallableObject, JSFunction, UNDEFINED
 
 
@@ -86,7 +86,7 @@ class TestRectangle:
 
     def test_rectangle_basic(self):
         """Test creating a Rectangle from JavaScript."""
-        ctx = JSContext()
+        ctx = Context()
 
         # Create and expose Rectangle constructor
         rect_constructor, rect_prototype = create_rectangle_constructor(
@@ -105,7 +105,7 @@ class TestRectangle:
 
     def test_rectangle_x_y_properties(self):
         """Test Rectangle x and y properties individually."""
-        ctx = JSContext()
+        ctx = Context()
 
         rect_constructor, rect_prototype = create_rectangle_constructor(
             ctx, ctx._object_prototype
@@ -117,7 +117,7 @@ class TestRectangle:
 
     def test_filled_rectangle_inheritance(self):
         """Test FilledRectangle inheriting from Rectangle."""
-        ctx = JSContext()
+        ctx = Context()
 
         rect_constructor, rect_prototype = create_rectangle_constructor(
             ctx, ctx._object_prototype
@@ -139,7 +139,7 @@ class TestRectangle:
 
     def test_rectangle_get_closure(self):
         """Test Rectangle.getClosure static method."""
-        ctx = JSContext()
+        ctx = Context()
 
         rect_constructor, rect_prototype = create_rectangle_constructor(
             ctx, ctx._object_prototype
@@ -156,7 +156,7 @@ class TestRectangle:
 
     def test_rectangle_call_callback(self):
         """Test Rectangle.call static method with JavaScript callback."""
-        ctx = JSContext()
+        ctx = Context()
 
         rect_constructor, rect_prototype = create_rectangle_constructor(
             ctx, ctx._object_prototype

--- a/tests/test_string_regex.py
+++ b/tests/test_string_regex.py
@@ -1,7 +1,7 @@
 """Test String methods that use RegExp."""
 
 import pytest
-from microjs import JSContext
+from microjs import Context
 
 
 class TestStringMatch:
@@ -9,19 +9,19 @@ class TestStringMatch:
 
     def test_match_simple(self):
         """Match with simple regex."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello world".match(/world/)')
         assert result[0] == "world"
 
     def test_match_no_match(self):
         """Match returns null when no match."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello".match(/xyz/)')
         assert result is None
 
     def test_match_with_groups(self):
         """Match captures groups."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"user@host".match(/(\\w+)@(\\w+)/)')
         assert result[0] == "user@host"
         assert result[1] == "user"
@@ -29,7 +29,7 @@ class TestStringMatch:
 
     def test_match_global(self):
         """Match with global flag returns all matches."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"abab".match(/a/g)')
         assert len(result) == 2
         assert result[0] == "a"
@@ -37,7 +37,7 @@ class TestStringMatch:
 
     def test_match_index(self):
         """Match result has index property."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var m = "hello world".match(/world/);
@@ -48,7 +48,7 @@ class TestStringMatch:
 
     def test_match_with_string_pattern(self):
         """Match with string pattern (not regex)."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello world".match("world")')
         assert result[0] == "world"
 
@@ -58,25 +58,25 @@ class TestStringSearch:
 
     def test_search_found(self):
         """Search returns index when found."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello world".search(/world/)')
         assert result == 6
 
     def test_search_not_found(self):
         """Search returns -1 when not found."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello".search(/xyz/)')
         assert result == -1
 
     def test_search_at_start(self):
         """Search finds match at start."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello world".search(/hello/)')
         assert result == 0
 
     def test_search_with_string(self):
         """Search with string pattern."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello world".search("wor")')
         assert result == 6
 
@@ -86,37 +86,37 @@ class TestStringReplace:
 
     def test_replace_simple(self):
         """Replace first occurrence."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello world".replace(/world/, "there")')
         assert result == "hello there"
 
     def test_replace_no_match(self):
         """Replace returns original when no match."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello".replace(/xyz/, "abc")')
         assert result == "hello"
 
     def test_replace_global(self):
         """Replace all occurrences with global flag."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"abab".replace(/a/g, "X")')
         assert result == "XbXb"
 
     def test_replace_with_groups(self):
         """Replace with group references."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello world".replace(/(\\w+) (\\w+)/, "$2 $1")')
         assert result == "world hello"
 
     def test_replace_string_pattern(self):
         """Replace with string pattern."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello world".replace("world", "there")')
         assert result == "hello there"
 
     def test_replace_special_replacement(self):
         """Replace with special patterns in replacement."""
-        ctx = JSContext()
+        ctx = Context()
         # $& is the matched substring
         result = ctx.eval('"hello".replace(/l/, "[$&]")')
         assert result == "he[l]lo"
@@ -127,13 +127,13 @@ class TestStringSplit:
 
     def test_split_regex(self):
         """Split with regex pattern."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"a1b2c3".split(/\\d/)')
         assert result == ["a", "b", "c", ""]
 
     def test_split_regex_with_groups(self):
         """Split with capturing groups includes captures."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"a1b2c".split(/(\\d)/)')
         # With captures: ["a", "1", "b", "2", "c"]
         assert "1" in result
@@ -141,7 +141,7 @@ class TestStringSplit:
 
     def test_split_with_limit(self):
         """Split with limit."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"a,b,c,d".split(/,/, 2)')
         assert len(result) == 2
         assert result == ["a", "b"]
@@ -152,25 +152,25 @@ class TestStringTrimStart:
 
     def test_trimStart_basic(self):
         """trimStart removes leading whitespace."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"  hello".trimStart()')
         assert result == "hello"
 
     def test_trimStart_preserves_trailing(self):
         """trimStart preserves trailing whitespace."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"  hello  ".trimStart()')
         assert result == "hello  "
 
     def test_trimStart_no_change(self):
         """trimStart on string without leading whitespace."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello".trimStart()')
         assert result == "hello"
 
     def test_trimStart_all_whitespace(self):
         """trimStart on all whitespace string."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"   ".trimStart()')
         assert result == ""
 
@@ -180,25 +180,25 @@ class TestStringTrimEnd:
 
     def test_trimEnd_basic(self):
         """trimEnd removes trailing whitespace."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello  ".trimEnd()')
         assert result == "hello"
 
     def test_trimEnd_preserves_leading(self):
         """trimEnd preserves leading whitespace."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"  hello  ".trimEnd()')
         assert result == "  hello"
 
     def test_trimEnd_no_change(self):
         """trimEnd on string without trailing whitespace."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello".trimEnd()')
         assert result == "hello"
 
     def test_trimEnd_all_whitespace(self):
         """trimEnd on all whitespace string."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"   ".trimEnd()')
         assert result == ""
 
@@ -208,30 +208,30 @@ class TestStringReplaceAll:
 
     def test_replaceAll_basic(self):
         """replaceAll replaces all occurrences."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"abcabc".replaceAll("b", "x")')
         assert result == "axcaxc"
 
     def test_replaceAll_no_match(self):
         """replaceAll with no match returns original."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello".replaceAll("x", "y")')
         assert result == "hello"
 
     def test_replaceAll_with_dollar_ampersand(self):
         """replaceAll with $& replacement pattern."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"abcabc".replaceAll("b", "$&$&")')
         assert result == "abbcabbc"
 
     def test_replaceAll_with_dollar_dollar(self):
         """replaceAll with $$ replacement pattern (literal $)."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"abcabc".replaceAll("b", "$$")')
         assert result == "a$ca$c"
 
     def test_replaceAll_complex_replacement(self):
         """replaceAll with combined $$ and $& patterns."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"abcabc".replaceAll("b", "a$$b$&")')
         assert result == "aa$bbcaa$bbc"

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -1,40 +1,40 @@
 """Tests for the JavaScript VM and context."""
 
 import pytest
-from microjs import JSContext, JSError, JSSyntaxError
+from microjs import Context, JSError, JSSyntaxError
 
 
-class TestJSContextBasics:
+class TestContextBasics:
     """Test basic context functionality."""
 
     def test_evaluate_number(self):
         """Evaluate a simple number."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("42") == 42
 
     def test_evaluate_float(self):
         """Evaluate a float."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("3.14") == 3.14
 
     def test_evaluate_string(self):
         """Evaluate a string literal."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval('"hello"') == "hello"
 
     def test_evaluate_boolean_true(self):
         """Evaluate boolean true."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("true") is True
 
     def test_evaluate_boolean_false(self):
         """Evaluate boolean false."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("false") is False
 
     def test_evaluate_null(self):
         """Evaluate null."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("null") is None
 
 
@@ -43,42 +43,42 @@ class TestArithmetic:
 
     def test_addition(self):
         """Test addition."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("1 + 2") == 3
 
     def test_subtraction(self):
         """Test subtraction."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("5 - 3") == 2
 
     def test_multiplication(self):
         """Test multiplication."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("4 * 5") == 20
 
     def test_division(self):
         """Test division."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("20 / 4") == 5.0
 
     def test_modulo(self):
         """Test modulo."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("10 % 3") == 1
 
     def test_complex_expression(self):
         """Test complex expression with precedence."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("2 + 3 * 4") == 14
 
     def test_parentheses(self):
         """Test parentheses."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("(2 + 3) * 4") == 20
 
     def test_unary_minus(self):
         """Test unary minus."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("-5") == -5
 
 
@@ -87,25 +87,25 @@ class TestVariables:
 
     def test_var_declaration(self):
         """Test variable declaration."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var x = 10; x")
         assert result == 10
 
     def test_var_assignment(self):
         """Test variable assignment."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var x = 5; x = 10; x")
         assert result == 10
 
     def test_compound_assignment(self):
         """Test compound assignment."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var x = 10; x += 5; x")
         assert result == 15
 
     def test_multiple_vars(self):
         """Test multiple variable declarations."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var a = 1, b = 2; a + b")
         assert result == 3
 
@@ -115,30 +115,30 @@ class TestComparisons:
 
     def test_less_than(self):
         """Test less than."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("1 < 2") is True
         assert ctx.eval("2 < 1") is False
 
     def test_greater_than(self):
         """Test greater than."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("2 > 1") is True
         assert ctx.eval("1 > 2") is False
 
     def test_equal(self):
         """Test equality."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("1 == 1") is True
         assert ctx.eval("1 == 2") is False
 
     def test_strict_equal(self):
         """Test strict equality."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("1 === 1") is True
 
     def test_not_equal(self):
         """Test not equal."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("1 != 2") is True
         assert ctx.eval("1 != 1") is False
 
@@ -148,19 +148,19 @@ class TestLogical:
 
     def test_logical_and(self):
         """Test logical AND."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("true && true") is True
         assert ctx.eval("true && false") is False
 
     def test_logical_or(self):
         """Test logical OR."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("false || true") is True
         assert ctx.eval("false || false") is False
 
     def test_logical_not(self):
         """Test logical NOT."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("!true") is False
         assert ctx.eval("!false") is True
 
@@ -170,19 +170,19 @@ class TestConditionals:
 
     def test_ternary(self):
         """Test ternary operator."""
-        ctx = JSContext()
+        ctx = Context()
         assert ctx.eval("true ? 1 : 2") == 1
         assert ctx.eval("false ? 1 : 2") == 2
 
     def test_if_statement(self):
         """Test if statement."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var x = 0; if (true) x = 1; x")
         assert result == 1
 
     def test_if_else_statement(self):
         """Test if-else statement."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var x = 0; if (false) x = 1; else x = 2; x")
         assert result == 2
 
@@ -192,25 +192,25 @@ class TestLoops:
 
     def test_while_loop(self):
         """Test while loop."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var x = 0; while (x < 5) x = x + 1; x")
         assert result == 5
 
     def test_for_loop(self):
         """Test for loop."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var sum = 0; for (var i = 0; i < 5; i++) sum = sum + i; sum")
         assert result == 10
 
     def test_do_while_loop(self):
         """Test do-while loop."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var x = 0; do { x = x + 1; } while (x < 3); x")
         assert result == 3
 
     def test_break(self):
         """Test break statement."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var x = 0; while (true) { x = x + 1; if (x >= 3) break; } x")
         assert result == 3
 
@@ -220,13 +220,13 @@ class TestFunctions:
 
     def test_function_declaration(self):
         """Test function declaration."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("function add(a, b) { return a + b; } add(2, 3)")
         assert result == 5
 
     def test_function_expression(self):
         """Test function expression."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var mul = function(a, b) { return a * b; }; mul(3, 4)")
         assert result == 12
 
@@ -236,19 +236,19 @@ class TestArrays:
 
     def test_array_literal(self):
         """Test array literal."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("[1, 2, 3]")
         assert result == [1, 2, 3]
 
     def test_array_access(self):
         """Test array access."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var arr = [10, 20, 30]; arr[1]")
         assert result == 20
 
     def test_array_length(self):
         """Test array length."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var arr = [1, 2, 3, 4, 5]; arr.length")
         assert result == 5
 
@@ -258,19 +258,19 @@ class TestObjects:
 
     def test_object_literal(self):
         """Test object literal."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("({a: 1, b: 2})")
         assert result == {"a": 1, "b": 2}
 
     def test_object_property_access(self):
         """Test object property access."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var obj = {x: 10}; obj.x")
         assert result == 10
 
     def test_object_property_set(self):
         """Test object property set."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var obj = {}; obj.x = 5; obj.x")
         assert result == 5
 
@@ -280,13 +280,13 @@ class TestStrings:
 
     def test_string_concatenation(self):
         """Test string concatenation."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello" + " " + "world"')
         assert result == "hello world"
 
     def test_string_length(self):
         """Test string length."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval('"hello".length')
         assert result == 5
 
@@ -296,14 +296,14 @@ class TestGlobalAccess:
 
     def test_set_global(self):
         """Test setting a global variable."""
-        ctx = JSContext()
+        ctx = Context()
         ctx.set("x", 42)
         result = ctx.eval("x")
         assert result == 42
 
     def test_get_global(self):
         """Test getting a global variable."""
-        ctx = JSContext()
+        ctx = Context()
         ctx.eval("var myVar = 100")
         result = ctx.get("myVar")
         assert result == 100
@@ -311,35 +311,35 @@ class TestGlobalAccess:
 
 """Test void operator."""
 import pytest
-from microjs import JSContext
+from microjs import Context
 
 
 class TestVoidOperator:
     def test_void_returns_undefined(self):
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("void 0")
         assert result is None or str(result) == "undefined"
 
     def test_void_expression(self):
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("void (1 + 2)")
         assert result is None or str(result) == "undefined"
 
     def test_void_function_call(self):
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var x = 0; void (x = 5); x")
         assert result == 5  # Side effect happens, but void returns undefined
 
 
 """Test for...of loops."""
 import pytest
-from microjs import JSContext
+from microjs import Context
 
 
 class TestForOf:
     def test_for_of_array(self):
         """Basic for...of with array."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var sum = 0;
@@ -354,7 +354,7 @@ class TestForOf:
 
     def test_for_of_string(self):
         """for...of with string iterates characters."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var chars = [];
@@ -369,13 +369,13 @@ class TestForOf:
 
 """Test getter/setter property syntax."""
 import pytest
-from microjs import JSContext
+from microjs import Context
 
 
 class TestGetterSetter:
     def test_getter(self):
         """Basic getter."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var obj = {
@@ -389,7 +389,7 @@ class TestGetterSetter:
 
     def test_setter(self):
         """Basic setter."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var obj = {
@@ -404,7 +404,7 @@ class TestGetterSetter:
 
     def test_getter_setter_combined(self):
         """Getter and setter together."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var obj = {
@@ -424,7 +424,7 @@ class TestTryFinallyBreak:
 
     def test_break_in_try_finally(self):
         """Break inside try should run finally block first."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var s = '';
@@ -447,14 +447,14 @@ class TestLabeledStatements:
 
     def test_labeled_break_after_while(self):
         """Labeled break after while without braces."""
-        ctx = JSContext()
+        ctx = Context()
         # Should not hang - breaks immediately
         result = ctx.eval("var x = 0; while (1) label: break; x")
         assert result == 0
 
     def test_labeled_break_in_block(self):
         """Labeled break in block."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var x = 0; label: { x = 1; break label; x = 2; } x")
         assert result == 1
 
@@ -464,19 +464,19 @@ class TestBuiltinConstructors:
 
     def test_new_object(self):
         """new Object() creates empty object."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var o = new Object(); o.x = 1; o.x")
         assert result == 1
 
     def test_new_array(self):
         """new Array() creates array."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("new Array(3).length")
         assert result == 3
 
     def test_new_array_with_elements(self):
         """new Array(1, 2, 3) creates array with elements."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval("var a = new Array(1, 2, 3); a[1]")
         assert result == 2
 
@@ -486,7 +486,7 @@ class TestASI:
 
     def test_break_asi_newline(self):
         """break followed by identifier on new line should not consume identifier as label."""
-        ctx = JSContext()
+        ctx = Context()
         # break should get ASI, i++ should be a separate statement
         result = ctx.eval(
             """
@@ -503,7 +503,7 @@ class TestASI:
 
     def test_continue_asi_newline(self):
         """continue followed by identifier on new line should not consume identifier as label."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var sum = 0;
@@ -524,7 +524,7 @@ class TestMemberUpdate:
 
     def test_object_property_postfix_increment(self):
         """a.x++ returns old value and increments."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var a = {x: 5};
@@ -537,7 +537,7 @@ class TestMemberUpdate:
 
     def test_object_property_prefix_increment(self):
         """++a.x returns new value."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var a = {x: 5};
@@ -550,7 +550,7 @@ class TestMemberUpdate:
 
     def test_array_element_postfix_increment(self):
         """arr[0]++ works."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var arr = [10];
@@ -563,7 +563,7 @@ class TestMemberUpdate:
 
     def test_object_property_decrement(self):
         """a.x-- works."""
-        ctx = JSContext()
+        ctx = Context()
         result = ctx.eval(
             """
             var a = {x: 5};
@@ -573,3 +573,15 @@ class TestMemberUpdate:
         )
         assert result[0] == 5
         assert result[1] == 4
+
+
+class TestBackwardsCompatibleAlias:
+    """Test that the JSContext alias works for backwards compatibility."""
+
+    def test_jscontext_alias_exists(self):
+        """JSContext should be importable as an alias for Context."""
+        from microjs import JSContext
+
+        ctx = JSContext()
+        result = ctx.eval("1 + 2")
+        assert result == 3


### PR DESCRIPTION
Rename the main context class from JSContext to Context for a cleaner
API. The JSContext name is preserved as an undocumented alias for
backwards compatibility with existing code.

- Rename class JSContext to Context in context.py
- Add JSContext = Context alias with explanatory comment
- Update __init__.py to export Context (primary) and JSContext (alias)
- Update all test files to use Context
- Update documentation (README.md, AGENTS.md, spec.md)
- Add test to protect the backwards-compatible alias from removal

> Rename JSContext to just Context in the code and test and docs
>
> Leave an undocumented JSContext alias with a comment explaining why it is there to avoid breaking any existing code (with one test to protect it against future removal)

https://gistpreview.github.io/?57e04088a065e59cd24efb0a15734eff/index.html