### PR TITLE
Fix optional lookahead capture semantics

### DIFF
--- a/open-problems.md
+++ b/open-problems.md
@@ -55,41 +55,6 @@ The Error constructor is a Python function that doesn't have access to the VM's 
 
 ---
 
-## Optional Lookahead Capture Semantics
-
-**Tests affected:**
-- `test_optional_lookahead_no_match`
-- `test_repeated_optional_lookahead`
-
-**Problem:**
-Pattern `/(?:(?=(abc)))?a/` on string `"abc"` should return `['a', None]` but returns `['a', 'abc']`.
-
-**Explanation:**
-The pattern has an optional non-capturing group containing a lookahead with a capture:
-1. `(?:...)?` - optional group
-2. `(?=(abc))` - lookahead that captures 'abc'
-3. `a` - literal match
-
-The lookahead succeeds (there's 'abc' ahead), captures 'abc', and the match proceeds. But the test expects the capture to be `None`.
-
-**Root cause:**
-This appears to be an edge case in ECMAScript regex semantics where captures inside optional groups that don't "contribute" to advancing the match should be reset. The exact semantics are complex and may require deeper ECMAScript spec analysis.
-
-**Current behavior:**
-- The lookahead runs and captures
-- The capture is preserved because we don't backtrack (the match succeeds)
-
-**Expected behavior (per test):**
-- Even though the lookahead "succeeded", because it's inside an optional group that could have been skipped, the capture should be undefined
-
-**Potential solutions:**
-1. Research ECMAScript spec section 21.2.2 (RegExp semantics) for exact rules
-2. Compare with test262 tests for conformance
-3. May require tracking whether an optional path was "necessary" vs "optional"
-
-**Complexity:** High - requires deep understanding of ECMAScript regex semantics
-
----
 
 ## Regex Test Suite Failures
 
@@ -122,11 +87,10 @@ The comprehensive regex test suites from the original QuickJS contain tests that
 |----------|-------------|------------|
 | Deep nesting/recursion | 5 | High |
 | Error location tracking | 2 | Medium |
-| Lookahead capture semantics | 2 | High |
 | Comprehensive test suites | 4 | Varies |
 
-**Total xfail tests:** 14
+**Total xfail tests:** 11
 
 Most issues fall into two categories:
 1. **Architectural limitations** (recursion, location tracking) - require significant refactoring
-2. **Spec edge cases** (lookahead captures) - require careful ECMAScript spec analysis
+2. **Spec edge cases** - require careful ECMAScript spec analysis

--- a/src/microjs/regex/opcodes.py
+++ b/src/microjs/regex/opcodes.py
@@ -69,6 +69,7 @@ class RegexOpCode(IntEnum):
     # State management (for ReDoS protection)
     SET_POS = auto()  # Save current position to register
     CHECK_ADVANCE = auto()  # Check that position advanced
+    RESET_IF_NO_ADV = auto()  # Reset captures if position didn't advance
 
     # Terminal
     MATCH = auto()  # Successful match
@@ -138,6 +139,11 @@ OPCODE_INFO = {
         "CHECK_ADVANCE",
         1,
         "Check position advanced (arg: reg_idx)",
+    ),
+    RegexOpCode.RESET_IF_NO_ADV: (
+        "RESET_IF_NO_ADV",
+        3,
+        "Reset captures if position unchanged (args: reg_idx, start_group, end_group)",
     ),
     RegexOpCode.MATCH: ("MATCH", 0, "Successful match"),
 }

--- a/src/microjs/regex/vm.py
+++ b/src/microjs/regex/vm.py
@@ -582,6 +582,19 @@ class RegexVM:
                     continue
                 pc += 1
 
+            elif opcode == Op.RESET_IF_NO_ADV:
+                reg_idx = instr[1]
+                start_group = instr[2]
+                end_group = instr[3]
+                # Reset captures if position didn't advance (zero-width match)
+                # This implements ECMAScript semantics where optional groups
+                # that match zero-width should have undefined captures
+                if reg_idx < len(registers) and registers[reg_idx] == sp:
+                    for i in range(start_group, end_group + 1):
+                        if i < len(captures):
+                            captures[i] = [-1, -1]
+                pc += 1
+
             elif opcode == Op.MATCH:
                 # Successful match!
                 groups = []

--- a/tests/test_known_issues.py
+++ b/tests/test_known_issues.py
@@ -77,23 +77,17 @@ class TestRegexCaptureGroups:
         expected = ["zaacbbbcac", "z", "ac", "a", None, "c"]
         assert result == expected
 
-    @pytest.mark.xfail(reason="Optional lookahead group retains capture")
     def test_optional_lookahead_no_match(self):
         """Optional lookahead that doesn't match should have undefined capture.
-
-        Issue: When an optional group containing a lookahead doesn't match,
-        the capture from the lookahead should be undefined. Currently the
-        capture from a previous successful lookahead attempt is retained.
 
         Pattern: /(?:(?=(abc)))?a/
         String:  'abc'
 
         The outer group (?:...)? is optional. The lookahead (?=(abc)) would
         match 'abc', but then 'a' must match. Since the lookahead consumed
-        nothing, 'a' matches at position 0. But since the outer optional
-        group could match (lookahead succeeded), it's unclear if the capture
-        should be retained. Per spec, if the outer group is skipped, captures
-        inside should be undefined.
+        nothing, 'a' matches at position 0. Since the optional group matched
+        zero-width (lookahead doesn't advance), captures inside should be
+        undefined per ECMAScript spec.
         """
         ctx = Context(time_limit=5.0)
         result = ctx.eval('/(?:(?=(abc)))?a/.exec("abc")')
@@ -102,13 +96,12 @@ class TestRegexCaptureGroups:
         expected = ["a", None]
         assert result == expected
 
-    @pytest.mark.xfail(reason="Repeated optional lookahead group retains capture")
     def test_repeated_optional_lookahead(self):
         """Repeated optional lookahead with {0,2} quantifier.
 
-        Issue: Similar to test_optional_lookahead_no_match, but with {0,2}.
-        The capture should be undefined since the lookahead group didn't
-        participate in the final match.
+        Similar to test_optional_lookahead_no_match, but with {0,2}.
+        The capture should be undefined since the lookahead group matched
+        zero-width (lookahead doesn't advance position).
         """
         ctx = Context(time_limit=5.0)
         result = ctx.eval('/(?:(?=(abc))){0,2}a/.exec("abc")')


### PR DESCRIPTION
Per ECMAScript spec, when an optional group matches but with zero-width
(e.g., contains only a lookahead), captures inside should be undefined.
This is because a zero-width optional match is equivalent to skipping
the group entirely.

Implementation:
- Add new RESET_IF_NO_ADV opcode that resets captures if position unchanged
- In compiler, detect optional groups with zero-width bodies (e.g., lookaheads)
- Emit SET_POS before and RESET_IF_NO_ADV after such bodies
- In VM, handle the new opcode to conditionally reset captures

This fixes the following tests:
- test_optional_lookahead_no_match
- test_repeated_optional_lookahead

Claude Code transcript: https://gistpreview.github.io/?65d1a6449a8077c59946435f485121bf/index.html